### PR TITLE
Included support for sm_86 (Ampere) + libcuda.so linking fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ PACKAGE_NAME = "torch_lap_cuda"
 
 @functools.lru_cache(maxsize=None)
 def cuda_archs() -> str:
-    return os.getenv("torch_lap_cuda_ARCHS", "75;80;89;90;100;120").split(";")
+    return os.getenv("torch_lap_cuda_ARCHS", "75;80;86;89;90;100;120").split(";")
 
 
 def get_platform():
@@ -92,7 +92,10 @@ nvcc_flags.append(f"arch=compute_{75},code=sm_{75}")
 for arch in cuda_archs():
     if bare_metal_version >= Version("11.1") and arch == "80":
         nvcc_flags.append("-gencode")
-        nvcc_flags.append("arch=compute_90,code=sm_90")
+        nvcc_flags.append("arch=compute_80,code=sm_80")
+    if bare_metal_version >= Version("11.1") and arch == "86":
+        nvcc_flags.append("-gencode")
+        nvcc_flags.append("arch=compute_86,code=sm_86")
     if bare_metal_version >= Version("11.8") and arch == "89":
         nvcc_flags.append("-gencode")
         nvcc_flags.append("arch=compute_89,code=sm_89")
@@ -124,6 +127,7 @@ ext_modules.append(
         include_dirs=[
             Path(this_dir) / "csrc" / "include",
         ],
+        extra_link_args=['-lcuda'],
     )
 )
 


### PR DESCRIPTION
Thanks for implementing this. I've provided a few changes that were necessary for the code to work on our setup, plus a correction on sm_80.

Benchmark results on A5000 GPU vs Ryzen Threadripper PRO 3975WX CPU (single-thread).

```
Benchmark for uniform random distribution:
|------------------------------------------------------------------|
| Batch Size | Dimension  |    Scipy     |   LAP CUDA   | Speedup  |
|------------|------------|--------------|--------------|----------|
|     1      |     64     |   0.000128   |   0.003617   |  0.04  x |
|     1      |    256     |   0.002425   |   0.062024   |  0.04  x |
|     1      |    512     |   0.014610   |   0.282605   |  0.05  x |
|     64     |     64     |   0.007645   |   0.002817   |  2.71  x |
|     64     |    256     |   0.157136   |   0.050888   |  3.09  x |
|     64     |    512     |   0.764792   |   0.400514   |  1.91  x |
|    256     |     64     |   0.031409   |   0.003799   |  8.27  x |
|    256     |    256     |   0.569253   |   0.193109   |  2.95  x |
|    256     |    512     |   2.469636   |   1.203457   |  2.05  x |
|------------------------------------------------------------------|

Benchmark for normal random distribution:
|------------------------------------------------------------------|
| Batch Size | Dimension  |    Scipy     |   LAP CUDA   | Speedup  |
|------------|------------|--------------|--------------|----------|
|     1      |     64     |   0.000099   |   0.001680   |  0.06  x |
|     1      |    256     |   0.002389   |   0.031391   |  0.08  x |
|     1      |    512     |   0.010587   |   0.337723   |  0.03  x |
|     64     |     64     |   0.007199   |   0.002247   |  3.20  x |
|     64     |    256     |   0.139408   |   0.080424   |  1.73  x |
|     64     |    512     |   0.517203   |   0.478052   |  1.08  x |
|    256     |     64     |   0.024858   |   0.011608   |  2.14  x |
|    256     |    256     |   0.441715   |   0.199253   |  2.22  x |
|    256     |    512     |   1.989071   |   1.200510   |  1.66  x |
|------------------------------------------------------------------|

Benchmark for integer random distribution:
|------------------------------------------------------------------|
| Batch Size | Dimension  |    Scipy     |   LAP CUDA   | Speedup  |
|------------|------------|--------------|--------------|----------|
|     1      |     64     |   0.000118   |   0.001052   |  0.11  x |
|     1      |    256     |   0.001513   |   0.001498   |  1.01  x |
|     1      |    512     |   0.006105   |   0.002465   |  2.48  x |
|     64     |     64     |   0.006033   |   0.001320   |  4.57  x |
|     64     |    256     |   0.103708   |   0.002968   |  34.94 x |
|     64     |    512     |   0.487973   |   0.006648   |  73.41 x |
|    256     |     64     |   0.027901   |   0.001896   |  14.72 x |
|    256     |    256     |   0.487980   |   0.007803   |  62.54 x |
|    256     |    512     |   1.811183   |   0.017997   | 100.64 x |
|------------------------------------------------------------------|
```

Note: For a fairer benchmark, it may be worth running the scipy test in parallel. 

```python
def test_scipy_lap(cost: torch.Tensor):
    """
    Test the scipy linear_sum_assignment function.
    """
    import multiprocessing as mp
    times = []
    pool = mp.Pool(mp.cpu_count())
    for _ in range(N_TRIALS):
        start = time.perf_counter()
        cost_ = cost.cpu().numpy()
        
        # for i in range(cost_.shape[0]):
        #     cost_i = cost_[i]
        #     linear_sum_assignment(cost_i)
        pool.map(linear_sum_assignment, cost_)

        times.append(time.perf_counter() - start)
    return np.mean(times)
```

This results in the following benchmark results for our setup. Note that we use 2 Threadrippers for this test:

```
|------------------------------------------------------------------|
| Batch Size | Dimension  |    Scipy     |   LAP CUDA   | Speedup  |
|------------|------------|--------------|--------------|----------|
|     1      |     64     |   0.001244   |   0.003636   |  0.34  x |
|     1      |    256     |   0.005183   |   0.063881   |  0.08  x |
|     1      |    512     |   0.017167   |   0.301514   |  0.06  x |
|     64     |     64     |   0.008457   |   0.006241   |  1.36  x |
|     64     |    256     |   0.041707   |   0.078776   |  0.53  x |
|     64     |    512     |   0.149412   |   0.402505   |  0.37  x |
|    256     |     64     |   0.027646   |   0.003562   |  7.76  x |
|    256     |    256     |   0.152300   |   0.173167   |  0.88  x |
|    256     |    512     |   0.560540   |   1.205245   |  0.47  x |
|------------------------------------------------------------------|

Benchmark for normal random distribution:
|------------------------------------------------------------------|
| Batch Size | Dimension  |    Scipy     |   LAP CUDA   | Speedup  |
|------------|------------|--------------|--------------|----------|
|     1      |     64     |   0.001116   |   0.001575   |  0.71  x |
|     1      |    256     |   0.004069   |   0.042123   |  0.10  x |
|     1      |    512     |   0.016073   |   0.272521   |  0.06  x |
|     64     |     64     |   0.007386   |   0.010641   |  0.69  x |
|     64     |    256     |   0.041318   |   0.076579   |  0.54  x |
|     64     |    512     |   0.149013   |   0.429933   |  0.35  x |
|    256     |     64     |   0.022961   |   0.003779   |  6.08  x |
|    256     |    256     |   0.154192   |   0.206820   |  0.75  x |
|    256     |    512     |   0.556844   |   1.208745   |  0.46  x |
|------------------------------------------------------------------|

Benchmark for integer random distribution:
|------------------------------------------------------------------|
| Batch Size | Dimension  |    Scipy     |   LAP CUDA   | Speedup  |
|------------|------------|--------------|--------------|----------|
|     1      |     64     |   0.001080   |   0.005080   |  0.21  x |
|     1      |    256     |   0.003967   |   0.001797   |  2.21  x |
|     1      |    512     |   0.013635   |   0.003106   |  4.39  x |
|     64     |     64     |   0.008474   |   0.006339   |  1.34  x |
|     64     |    256     |   0.042389   |   0.003112   |  13.62 x |
|     64     |    512     |   0.150771   |   0.007083   |  21.28 x |
|    256     |     64     |   0.024514   |   0.001949   |  12.58 x |
|    256     |    256     |   0.152807   |   0.007067   |  21.62 x |
|    256     |    512     |   0.555482   |   0.017840   |  31.14 x |
|------------------------------------------------------------------|
```

Given these results, I think there is a case to be made for converting float data to ints for the pairing process.

Update: Integer test is a lot more difficult for GPUs when using a larger range of ints (0-10000)

```
Benchmark for integer random distribution:
|------------------------------------------------------------------|
| Batch Size | Dimension  |    Scipy     |   LAP CUDA   | Speedup  |
|------------|------------|--------------|--------------|----------|
|     1      |     64     |   0.001345   |   0.003350   |  0.40  x |
|     1      |    256     |   0.004200   |   0.033013   |  0.13  x |
|     1      |    512     |   0.017326   |   0.075243   |  0.23  x |
|     64     |     64     |   0.008718   |   0.002649   |  3.29  x |
|     64     |    256     |   0.046855   |   0.041062   |  1.14  x |
|     64     |    512     |   0.152134   |   0.116666   |  1.30  x |
|    256     |     64     |   0.027491   |   0.003017   |  9.11  x |
|    256     |    256     |   0.152624   |   0.123350   |  1.24  x |
|    256     |    512     |   0.559441   |   0.288146   |  1.94  x |
|------------------------------------------------------------------|
```