### PR TITLE
PyTorch allocator integration + general optimisations / stability for 1024 threads

### DIFF
--- a/csrc/LAP/Hung_lap.cuh
+++ b/csrc/LAP/Hung_lap.cuh
@@ -28,24 +28,12 @@ public:
   TLAP(at::Tensor cost_matrix_)
       : cost_matrix(cost_matrix_)
   {
-    int64_t n_problem = cost_matrix.size(0);
-    int64_t n_rows = cost_matrix.size(1);
-    int64_t n_cols = cost_matrix.size(2);
-    // cudaOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, THA<data>);
+    int n_problem = cost_matrix.size(0);
+    int n_rows = cost_matrix.size(1);
+    int n_cols = cost_matrix.size(2);
     
-    // cudaDeviceProp prop;
-    // cudaGetDeviceProperties(&prop, cost_matrix.device().index());
-    // blockSize = prop.maxThreadsPerBlock;
-    // blockSize = 512;
     gridSize = n_problem;
-    // cudaOccupancyMaxPotentialBlockSize(
-    //     &gridSize,
-    //     &blockSize,
-    //     THA<data>
-    // );
-    
-    // th.SIZE = n_rows;
-    // th.NPROB = n_problem;
+
     // external memory
     th.slack = cost_matrix.data_ptr<data>();
 
@@ -88,7 +76,7 @@ public:
     at::cuda::CUDAStream cuda_stream = at::cuda::getCurrentCUDAStream();
     cudaStream_t stream = cuda_stream.stream();
     CUDA_RUNTIME(cudaStreamSynchronize(stream));
-    execKernel((THA<data>), gridSize, blockSize, stream, true, th);
+    execKernel((THA<data>), gridSize, N_WARPS, stream, true, th);
     CUDA_RUNTIME(cudaStreamSynchronize(stream));
     return column_of_star_at_row;
   };

--- a/csrc/LAP/Hung_lap.cuh
+++ b/csrc/LAP/Hung_lap.cuh
@@ -3,122 +3,93 @@
 #include "lap_kernels.cuh"
 #include <thrust/reduce.h>
 #include <thrust/execution_policy.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDACachingAllocator.h>
 
 template <typename data>
 class TLAP
 {
 private:
-  uint nprob_;
-  int dev_, maxtile;
-  size_t size_, h_nrows, h_ncols;
-  data *Tcost_;
-  uint num_blocks_4, num_blocks_reduction;
+  int gridSize;
+  at::Tensor cost_matrix;
+
+  at::Tensor zeros;
+  at::Tensor zeros_sizes;
+  at::Tensor row_of_star_at_column, column_of_star_at_row;
+  at::Tensor cover_row, cover_column;
+  at::Tensor column_of_prime_at_row, row_of_green_at_column;
+  // at::Tensor row_of_prime_at_column, column_of_green_at_row;
+  at::Tensor tail;
+  at::Tensor d_min_in_mat;
 
 public:
   // Blank constructor
   TILED_HANDLE<data> th;
-  TLAP(uint nproblem, size_t size, int dev = 0)
-      : nprob_(nproblem), dev_(dev), size_(size)
+  TLAP(at::Tensor cost_matrix_)
+      : cost_matrix(cost_matrix_)
   {
-    th.memoryloc = EXTERNAL;
-    allocate(nproblem, size, dev);
-    CUDA_RUNTIME(cudaDeviceSynchronize());
-  }
-  TLAP(uint nproblem, data *tcost, size_t size, int dev = 0)
-      : nprob_(nproblem), Tcost_(tcost), dev_(dev), size_(size)
-  {
-    th.memoryloc = INTERNAL;
-    allocate(nproblem, size, dev);
-    th.cost = Tcost_;
-    // initialize slack
-    CUDA_RUNTIME(cudaMemcpy(th.slack, Tcost_, nproblem * size * size * sizeof(data), cudaMemcpyDeviceToDevice));
-    CUDA_RUNTIME(cudaDeviceSynchronize());
-  };
-  // destructor
-  ~TLAP()
-  {
-    th.clear();
-  }
-
-  void solve()
-  {
-    if (th.memoryloc == EXTERNAL)
-    {
-      Log(critical, "Unassigned external memory, exiting...");
-      return;
-    }
-    int nblocks = maxtile;
-    Log(debug, "nblocks: %d\n", nblocks);
-    execKernel((THA<data, nthr>), nblocks, nthr, dev_, true, th);
-    CUDA_RUNTIME(cudaDeviceSynchronize());
-  }
-
-  void solve(data *costs, int *row_ass, data *row_duals, data *col_duals, data *obj)
-  {
-    if (th.memoryloc == INTERNAL)
-    {
-      Log(debug, "Doubly assigned external memory, exiting...");
-      return;
-    }
-    th.cost = costs;
-    th.row_of_star_at_column = row_ass;
-    th.min_in_rows = row_duals;
-    th.min_in_cols = col_duals;
-    th.objective = obj;
-    int nblocks = maxtile;
-    CUDA_RUNTIME(cudaMemcpy(th.slack, th.cost, nprob_ * size_ * size_ * sizeof(data), cudaMemcpyDefault));
-    Log(debug, "nblocks from external solve: %d\n", nblocks);
-
-    execKernel((THA<data, nthr>), nblocks, nthr, dev_, true, th);
-  }
-
-  void allocate(uint nproblem, size_t size, int dev)
-  {
-    h_nrows = size;
-    h_ncols = size;
-    CUDA_RUNTIME(cudaSetDevice(dev_));
-    CUDA_RUNTIME(cudaMemcpyToSymbol(NPROB, &nprob_, sizeof(NPROB)));
-    CUDA_RUNTIME(cudaMemcpyToSymbol(SIZE, &size, sizeof(SIZE)));
-    CUDA_RUNTIME(cudaMemcpyToSymbol(nrows, &h_nrows, sizeof(SIZE)));
-    CUDA_RUNTIME(cudaMemcpyToSymbol(ncols, &h_ncols, sizeof(SIZE)));
-
-    int max_active_blocks = 1;
-    CUDAContext context;
-    int num_SMs = context.num_SMs;
-
-    cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_active_blocks,
-                                                  THA<data, nthr>,
-                                                  nthr, 0);
-    max_active_blocks *= num_SMs;
-    maxtile = MIN(nproblem, max_active_blocks);
-    Log(debug, "Grid dimension %d, max active blocks %d", maxtile, max_active_blocks);
-
+    int64_t n_problem = cost_matrix.size(0);
+    int64_t n_rows = cost_matrix.size(1);
+    int64_t n_cols = cost_matrix.size(2);
+    // cudaOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, THA<data>);
+    
+    // cudaDeviceProp prop;
+    // cudaGetDeviceProperties(&prop, cost_matrix.device().index());
+    // blockSize = prop.maxThreadsPerBlock;
+    // blockSize = 512;
+    gridSize = n_problem;
+    // cudaOccupancyMaxPotentialBlockSize(
+    //     &gridSize,
+    //     &blockSize,
+    //     THA<data>
+    // );
+    
+    // th.SIZE = n_rows;
+    // th.NPROB = n_problem;
     // external memory
-    CUDA_RUNTIME(cudaMalloc((void **)&th.slack, nproblem * size * size * sizeof(data)));
-    CUDA_RUNTIME(cudaMalloc((void **)&th.column_of_star_at_row, nproblem * h_nrows * sizeof(int)));
+    th.slack = cost_matrix.data_ptr<data>();
+
+    auto input_dtype = torch::CppTypeToScalarType<data>();
+    auto options = torch::TensorOptions().device(cost_matrix.device()).requires_grad(false);
+    column_of_star_at_row = at::empty({n_problem, n_rows}, options.dtype(torch::kInt32));
+    th.column_of_star_at_row = column_of_star_at_row.data_ptr<int>();
+    row_of_star_at_column = at::empty({n_problem, n_cols}, options.dtype(torch::kInt32));
+    th.row_of_star_at_column = row_of_star_at_column.data_ptr<int>();
 
     // internal memory
-    CUDA_RUNTIME(cudaMalloc((void **)&th.zeros, maxtile * h_nrows * h_ncols * sizeof(size_t)));
-    CUDA_RUNTIME(cudaMemset(th.zeros, 0, maxtile * h_nrows * h_ncols * sizeof(size_t)));
+    zeros = at::empty({gridSize, n_rows, n_cols}, options.dtype(torch::kLong));
+    // organised by column, with n_cols striding
+    th.zeros = zeros.data_ptr<int64_t>();
+    zeros_sizes = at::empty({gridSize, n_rows}, options.dtype(torch::kInt32));
+    th.zeros_sizes = zeros_sizes.data_ptr<int>();
+    // zeros_sizes = at::empty({gridSize}, options.dtype(torch::kInt32));
+    // th.zeros_sizes = zeros_sizes.data_ptr<int>();
 
-    CUDA_RUNTIME(cudaMalloc((void **)&th.cover_row, maxtile * h_nrows * sizeof(int)));
-    CUDA_RUNTIME(cudaMalloc((void **)&th.cover_column, maxtile * h_ncols * sizeof(int)));
-    CUDA_RUNTIME(cudaMalloc((void **)&th.column_of_prime_at_row, maxtile * h_nrows * sizeof(int)));
-    CUDA_RUNTIME(cudaMalloc((void **)&th.row_of_green_at_column, maxtile * h_ncols * sizeof(int)));
+    cover_row = at::empty({gridSize, n_rows}, options.dtype(torch::kInt32));
+    th.cover_row = cover_row.data_ptr<int>();
+    cover_column = at::empty({gridSize, n_cols}, options.dtype(torch::kInt32));
+    th.cover_column = cover_column.data_ptr<int>();
+    column_of_prime_at_row = at::empty({gridSize, n_rows}, options.dtype(torch::kInt32));
+    th.column_of_prime_at_row = column_of_prime_at_row.data_ptr<int>();
+    row_of_green_at_column = at::empty({gridSize, n_cols}, options.dtype(torch::kInt32));
+    th.row_of_green_at_column = row_of_green_at_column.data_ptr<int>();
 
-    CUDA_RUNTIME(cudaMalloc((void **)&th.max_in_mat_row, maxtile * h_nrows * sizeof(data)));
-    CUDA_RUNTIME(cudaMalloc((void **)&th.max_in_mat_col, maxtile * h_ncols * sizeof(data)));
-    CUDA_RUNTIME(cudaMalloc((void **)&th.d_min_in_mat, maxtile * 1 * sizeof(data)));
-    CUDA_RUNTIME(cudaMalloc((void **)&th.tail, 1 * sizeof(uint)));
+    d_min_in_mat = at::empty({gridSize}, options.dtype(input_dtype));
+    th.d_min_in_mat = d_min_in_mat.data_ptr<data>();
+    tail = at::zeros({1}, options.dtype(torch::kInt32));
+    th.tail = tail.data_ptr<int>();
 
-    CUDA_RUNTIME(cudaMemset(th.tail, 0, sizeof(uint)));
-    // CUDA_RUNTIME(cudaDeviceSynchronize());
-    if (th.memoryloc == INTERNAL)
-    {
-      CUDA_RUNTIME(cudaMalloc((void **)&th.min_in_rows, maxtile * h_nrows * sizeof(data)));
-      CUDA_RUNTIME(cudaMalloc((void **)&th.min_in_cols, maxtile * h_ncols * sizeof(data)));
-      CUDA_RUNTIME(cudaMalloc((void **)&th.row_of_star_at_column, maxtile * h_ncols * sizeof(int)));
-      CUDA_RUNTIME(cudaMallocManaged((void **)&th.objective, nproblem * 1 * sizeof(data)));
-    }
-  }
+    CUDA_RUNTIME(cudaMemcpyToSymbol(NPROB, &n_problem, sizeof(NPROB)));
+    CUDA_RUNTIME(cudaMemcpyToSymbol(SIZE, &n_rows, sizeof(SIZE)));
+  };
+
+  at::Tensor solve()
+  {
+    at::cuda::CUDAStream cuda_stream = at::cuda::getCurrentCUDAStream();
+    cudaStream_t stream = cuda_stream.stream();
+    CUDA_RUNTIME(cudaStreamSynchronize(stream));
+    execKernel((THA<data>), gridSize, blockSize, stream, true, th);
+    CUDA_RUNTIME(cudaStreamSynchronize(stream));
+    return column_of_star_at_row;
+  };
 };

--- a/csrc/LAP/device_utils.cuh
+++ b/csrc/LAP/device_utils.cuh
@@ -1,6 +1,7 @@
 #pragma once
 #include "../include/utils.cuh"
 #include "../include/defs.cuh"
+#include <ATen/ATen.h>
 
 #define checkpoint()                                   \
   {                                                    \
@@ -13,150 +14,39 @@
     __syncthreads();                                   \
   }
 
-enum MemoryLoc
-{
-  INTERNAL,
-  EXTERNAL
-};
-
 template <typename data = int>
 struct TILED_HANDLE
 {
-  MemoryLoc memoryloc;
-  data *cost;
   data *slack;
-  data *min_in_rows;
-  data *min_in_cols;
-  data *objective;
+  data *min_in_rows, *min_in_cols;
 
-  size_t *zeros;
-  int *row_of_star_at_column;
-  int *column_of_star_at_row; // In unified memory
+  int64_t *zeros;
+  int *zeros_sizes;
+  int *row_of_star_at_column, *column_of_star_at_row;
   int *cover_row, *cover_column;
   int *column_of_prime_at_row, *row_of_green_at_column;
-  uint *tail;
 
-  data *max_in_mat_row, *max_in_mat_col, *d_min_in_mat;
-  int row_mask;
-
-  void clear()
-  {
-    // CUDA_RUNTIME(cudaFree(cost));  //Already cleared to save memory
-    if (memoryloc == INTERNAL)
-    {
-      CUDA_RUNTIME(cudaFree(min_in_rows));
-      CUDA_RUNTIME(cudaFree(min_in_cols));
-      CUDA_RUNTIME(cudaFree(row_of_star_at_column));
-      CUDA_RUNTIME(cudaFree(objective));
-    }
-    CUDA_RUNTIME(cudaFree(slack));
-    CUDA_RUNTIME(cudaFree(zeros));
-    CUDA_RUNTIME(cudaFree(column_of_star_at_row));
-    CUDA_RUNTIME(cudaFree(cover_row));
-    CUDA_RUNTIME(cudaFree(cover_column));
-    CUDA_RUNTIME(cudaFree(column_of_prime_at_row));
-    CUDA_RUNTIME(cudaFree(row_of_green_at_column));
-
-    CUDA_RUNTIME(cudaFree(max_in_mat_row));
-    CUDA_RUNTIME(cudaFree(max_in_mat_col));
-    CUDA_RUNTIME(cudaFree(d_min_in_mat));
-    CUDA_RUNTIME(cudaFree(tail));
-  };
+  int *tail;
+  data *d_min_in_mat;
 };
 
 template <typename data = int>
 struct GLOBAL_HANDLE
 {
-  data *cost;
   data *slack;
-  data *min_in_rows;
-  data *min_in_cols;
+  data *min_in_rows, *min_in_cols;
 
-  size_t *zeros;
-  int *row_of_star_at_column;
-  int *column_of_star_at_row; // In unified memory
+  int64_t *zeros;
+  int *zeros_sizes;
+  int *row_of_star_at_column, *column_of_star_at_row;
   int *cover_row, *cover_column;
   int *column_of_prime_at_row, *row_of_green_at_column;
 
-  data *max_in_mat_row, *max_in_mat_col, *d_min_in_mat, *objective;
-  int row_mask;
-
-  void clear()
-  {
-    CUDA_RUNTIME(cudaFree(cost)); // Already cleared to save memory
-    CUDA_RUNTIME(cudaFree(slack));
-    CUDA_RUNTIME(cudaFree(min_in_rows));
-    CUDA_RUNTIME(cudaFree(min_in_cols));
-
-    CUDA_RUNTIME(cudaFree(zeros));
-    CUDA_RUNTIME(cudaFree(row_of_star_at_column));
-    CUDA_RUNTIME(cudaFree(column_of_star_at_row));
-    CUDA_RUNTIME(cudaFree(cover_row));
-    CUDA_RUNTIME(cudaFree(cover_column));
-    CUDA_RUNTIME(cudaFree(column_of_prime_at_row));
-    CUDA_RUNTIME(cudaFree(row_of_green_at_column));
-
-    CUDA_RUNTIME(cudaFree(max_in_mat_row));
-    CUDA_RUNTIME(cudaFree(max_in_mat_col));
-    CUDA_RUNTIME(cudaFree(d_min_in_mat));
-    CUDA_RUNTIME(cudaFree(objective));
-  };
+  data *d_min_in_mat;
 };
 
 struct SHARED_HANDLE
 {
-  int zeros_size, n_matches;
-  bool goto_5, repeat_kernel;
-};
-
-template <int NPART = 1>
-struct BLOCK_HANDLE
-{
-  int zeros_size[NPART], n_matches[NPART];
-  bool goto_5[NPART], repeat_kernel[NPART];
-};
-
-struct WARP_HANDLE
-{
-  int &zeros_size, &n_matches;
-  bool &goto_5, &repeat_kernel;
-};
-
-void memstatus(const char *message)
-{
-  size_t t, f;
-  float total, free;
-  cuMemGetInfo(&f, &t);
-  total = (t * 1.0) / (1024 * 1024);
-  free = (f * 1.0) / (1024 * 1024);
-  Log(info, "%s occupied memory: %.1f MB", message, total - free);
-}
-
-struct CUDAContext
-{
-  uint32_t max_threads_per_SM;
-  uint32_t num_SMs;
-  uint32_t shared_mem_size_per_block;
-  uint32_t shared_mem_size_per_sm;
-
-  CUDAContext()
-  {
-    /*get the maximal number of threads in an SM*/
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop, 0); /*currently 0th device*/
-    max_threads_per_SM = prop.maxThreadsPerMultiProcessor;
-    Log(debug, "Max threads per SM %u", max_threads_per_SM);
-
-    // Log(LogPriorityEnum::info, "Shared MemPerBlock: %zu, PerSM: %zu", prop.sharedMemPerBlock, prop.sharedMemPerMultiprocessor);
-    shared_mem_size_per_block = prop.sharedMemPerBlock;
-    shared_mem_size_per_sm = prop.sharedMemPerMultiprocessor;
-    num_SMs = prop.multiProcessorCount;
-  }
-
-  uint32_t GetConCBlocks(uint32_t block_size)
-  {
-    auto conc_blocks_per_SM = max_threads_per_SM / block_size; /*assume regs are not limited*/
-    Log(LogPriorityEnum::info, "#SMs: %d, con blocks/SM: %d", num_SMs, conc_blocks_per_SM);
-    return conc_blocks_per_SM;
-  }
+  int n_matches;
+  bool goto_5, repeat_step_4;
 };

--- a/csrc/LAP/device_utils.cuh
+++ b/csrc/LAP/device_utils.cuh
@@ -47,6 +47,5 @@ struct GLOBAL_HANDLE
 
 struct SHARED_HANDLE
 {
-  int n_matches;
-  bool goto_5, repeat_step_4;
+  int n_matches, goto_5;
 };

--- a/csrc/LAP/lap_kernels.cuh
+++ b/csrc/LAP/lap_kernels.cuh
@@ -1,19 +1,16 @@
 #pragma once
 #include "../include/utils.cuh"
 #include "device_utils.cuh"
-#include "cub/cub.cuh"
+#include <cub/cub.cuh>
+
+#define FULLWARP 0xffffffff
+#define blockSize 1024
 
 #define fundef template <typename data = int> \
-__device__ __forceinline__
+__forceinline__ __device__
 
-const uint nthr = 512;
-
-__constant__ size_t SIZE;
-__constant__ uint NPROB;
-__constant__ size_t nrows;
-__constant__ size_t ncols;
-
-const int n_threads_reduction = nthr;
+__device__ __constant__ size_t SIZE;
+__device__ __constant__ size_t NPROB;
 
 fundef void init(GLOBAL_HANDLE<data> &gh) // with single block
 {
@@ -25,74 +22,7 @@ fundef void init(GLOBAL_HANDLE<data> &gh) // with single block
     gh.column_of_star_at_row[i] = -1;
     gh.cover_column[i] = 0;
     gh.row_of_star_at_column[i] = -1;
-  }
-}
-
-fundef void calc_col_min(GLOBAL_HANDLE<data> &gh) // with single block
-{
-  for (size_t col = 0; col < SIZE; col++)
-  {
-    size_t i = (size_t)threadIdx.x * SIZE + col;
-    data thread_min = (data)MAX_DATA;
-
-    while (i <= SIZE * (SIZE - 1) + col)
-    {
-      thread_min = min(thread_min, gh.slack[i]);
-      i += (size_t)blockDim.x * SIZE;
-    }
-    __syncthreads();
-    typedef cub::BlockReduce<data, n_threads_reduction> BR;
-    __shared__ typename BR::TempStorage temp_storage;
-    thread_min = BR(temp_storage).Reduce(thread_min, cub::Min());
-    if (threadIdx.x == 0)
-    {
-      gh.min_in_cols[col] = thread_min;
-    }
-    __syncthreads();
-  }
-}
-
-fundef void col_sub(GLOBAL_HANDLE<data> &gh) // with single block
-{
-  // uint i = (size_t)blockDim.x * (size_t)blockIdx.x + (size_t)threadIdx.x;
-  for (size_t i = threadIdx.x; i < SIZE * SIZE; i += blockDim.x)
-  {
-    size_t l = i % SIZE;
-    gh.slack[i] = gh.slack[i] - gh.min_in_cols[l]; // subtract the minimum in col from that col
-  }
-}
-
-fundef void calc_row_min(GLOBAL_HANDLE<data> &gh) // with single block
-{
-
-  typedef cub::BlockReduce<data, n_threads_reduction> BR;
-  __shared__ typename BR::TempStorage temp_storage;
-  // size_t i = (size_t)blockIdx.x * SIZE + (size_t)threadIdx.x;
-  for (size_t row = 0; row < SIZE; row++)
-  {
-    data thread_min = MAX_DATA;
-    for (size_t i = threadIdx.x + row * SIZE; i < SIZE * (row + 1); i += blockDim.x)
-    {
-      thread_min = min(thread_min, gh.slack[i]);
-    }
-    __syncthreads();
-    thread_min = BR(temp_storage).Reduce(thread_min, cub::Min());
-    if (threadIdx.x == 0)
-    {
-      gh.min_in_rows[row] = thread_min;
-    }
-    __syncthreads();
-  }
-}
-
-fundef void row_sub(GLOBAL_HANDLE<data> &gh, SHARED_HANDLE &sh) // with single block
-{
-  for (size_t i = threadIdx.x; i < SIZE * SIZE; i += blockDim.x)
-  {
-    size_t c = i / SIZE;
-    gh.slack[i] = gh.slack[i] - gh.min_in_rows[c]; // subtract the minimum in row from that row
-    if (i == 0)
-      sh.zeros_size = 0;
+    gh.zeros_sizes[i] = 0;
   }
 }
 
@@ -101,88 +31,76 @@ fundef bool near_zero(data val)
   return ((val < eps) && (val > -eps));
 }
 
-fundef void compress_matrix(GLOBAL_HANDLE<data> &gh, SHARED_HANDLE &sh) // with single block
+fundef void row_sub(GLOBAL_HANDLE<data> &gh) 
 {
-  // size_t i = (size_t)blockDim.x * (size_t)blockIdx.x + (size_t)threadIdx.x;
-  for (size_t i = threadIdx.x; i < SIZE * SIZE; i += blockDim.x)
-  {
-    if (near_zero(gh.slack[i]))
-    {
-      size_t j = (size_t)atomicAdd(&sh.zeros_size, 1);
-      gh.zeros[j] = i; // saves index of zeros in slack matrix per block
+  typedef cub::BlockReduce<data, blockSize> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  __shared__ data row_min;
+  for (size_t row = 0; row < SIZE; row++) {
+    data thread_min = (data)MAX_DATA;
+    for (size_t col = threadIdx.x; col < SIZE; col += blockDim.x)
+      thread_min = min(thread_min, gh.slack[row * SIZE + col]);
+
+    thread_min = BlockReduce(temp_storage).Reduce(thread_min, cub::Min());
+    if (threadIdx.x == 0)
+      row_min = thread_min;
+    __syncthreads();
+
+    for (size_t col = threadIdx.x; col < SIZE; col += blockDim.x)
+      gh.slack[row * SIZE + col] -= row_min;
+  }
+}
+
+fundef void col_sub_and_compress_matrix(GLOBAL_HANDLE<data> &gh) 
+{
+  for (size_t col = threadIdx.x; col < SIZE; col += blockDim.x) {
+    data col_min = (data)MAX_DATA;
+    for (size_t row = 0; row < SIZE; row++)
+      col_min = min(col_min, gh.slack[row * SIZE + col]);
+    
+    for (size_t row = 0; row < SIZE; row++) {
+      size_t i = row * SIZE + col;
+      data x = gh.slack[i] - col_min;
+      gh.slack[i] = x;
+      if (x == 0)
+      // if (near_zero(gh.slack[i]))
+      {
+        int z_col = atomicAdd(&gh.zeros_sizes[row], 1);
+        gh.zeros[row * SIZE + z_col] = col;
+      }
     }
   }
 }
 
 fundef void step_2(GLOBAL_HANDLE<data> &gh, SHARED_HANDLE &sh)
 {
-  uint i = threadIdx.x;
-  __shared__ bool repeat;
-  __shared__ bool s_repeat_kernel;
-  if (i == 0)
-    s_repeat_kernel = false;
-
-  do
+  for (int row = threadIdx.x; row < SIZE; row += blockDim.x) 
   {
-    __syncthreads();
-    if (i == 0)
-      repeat = false;
-    __syncthreads();
-
-    for (int j = i; j < sh.zeros_size; j += blockDim.x)
+    for (int z_col = 0; z_col < gh.zeros_sizes[row]; z_col++) 
     {
-      uint z = gh.zeros[j];
-      uint l = z % nrows;
-      uint c = z / nrows;
-      if (gh.cover_row[l] == 0 &&
-          gh.cover_column[c] == 0)
+      int col = gh.zeros[row * SIZE + z_col];
+      if (!atomicExch((int *)&(gh.cover_column[col]), 1)) 
       {
-        if (!atomicExch((int *)&(gh.cover_row[l]), 1))
-        {
-          // only one thread gets the line
-          if (!atomicExch((int *)&(gh.cover_column[c]), 1))
-          {
-            // only one thread gets the column
-            gh.row_of_star_at_column[c] = l;
-            gh.column_of_star_at_row[l] = c;
-          }
-          else
-          {
-            gh.cover_row[l] = 0;
-            repeat = true;
-            s_repeat_kernel = true;
-          }
-        }
+        gh.row_of_star_at_column[col] = row;
+        gh.column_of_star_at_row[row] = col;
+        break;
       }
     }
-    __syncthreads();
-  } while (repeat);
-  if (s_repeat_kernel)
-    sh.repeat_kernel = true;
-}
-
-fundef void step_3_init(GLOBAL_HANDLE<data> &gh, SHARED_HANDLE &sh) // For single block
-{
-  for (size_t i = threadIdx.x; i < nrows; i += blockDim.x)
-  {
-    gh.cover_row[i] = 0;
-    gh.cover_column[i] = 0;
   }
-  if (threadIdx.x == 0)
-    sh.n_matches = 0;
 }
 
 fundef void step_3(GLOBAL_HANDLE<data> &gh, SHARED_HANDLE &sh) // For single block
 {
-  // size_t i = (size_t)blockDim.x * (size_t)blockIdx.x + (size_t)threadIdx.x;
-  for (size_t i = threadIdx.x; i < nrows; i += blockDim.x)
+  if (threadIdx.x == 0)
+    sh.n_matches = 0;
+  __syncthreads();
+
+  for (size_t i = threadIdx.x; i < SIZE; i += blockDim.x)
   {
-    // printf("i %lu, rosc %d\n", i, gh.row_of_star_at_column[i]);
-    if (gh.row_of_star_at_column[i] >= 0)
-    {
-      gh.cover_column[i] = 1;
+    gh.cover_row[i] = 0;
+    gh.cover_column[i] = (gh.row_of_star_at_column[i] >= 0);
+    if (gh.cover_column[i])
       atomicAdd((int *)&sh.n_matches, 1);
-    }
   }
 }
 
@@ -194,7 +112,7 @@ fundef void step_3(GLOBAL_HANDLE<data> &gh, SHARED_HANDLE &sh) // For single blo
 // uncovered zeros left. Save the smallest uncovered value and
 // Go to Step 6.
 
-fundef void step_4_init(GLOBAL_HANDLE<data> &gh)
+fundef void step_4_init(GLOBAL_HANDLE<data> &gh, SHARED_HANDLE &sh)
 {
   for (size_t i = threadIdx.x; i < SIZE; i += blockDim.x)
   {
@@ -205,107 +123,85 @@ fundef void step_4_init(GLOBAL_HANDLE<data> &gh)
 
 fundef void step_4(GLOBAL_HANDLE<data> &gh, SHARED_HANDLE &sh)
 {
-  const size_t i = threadIdx.x;
-  __shared__ bool s_found;
-  volatile int *v_cover_row = gh.cover_row;
-  volatile int *v_cover_column = gh.cover_column;
-  if (i == 0)
-  {
-    sh.goto_5 = false;
-    sh.repeat_kernel = false;
-  }
-  __syncthreads();
+  // volatile int* v_cover_row = gh.cover_row;
+  typedef cub::BlockReduce<data, blockSize> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage_found;
+  __shared__ typename BlockReduce::TempStorage temp_storage_goto;
+  __shared__ int warp_uncovered_found;
+  volatile int* v_cover_column = gh.cover_column;
+  int goto_5_flag = false;
   do
   {
-    __syncthreads();
-    if (i == 0)
-      s_found = false;
-    __syncthreads();
-    for (size_t j = threadIdx.x; j < sh.zeros_size; j += blockDim.x)
+    int uncovered_found = false;
+    for (size_t row = threadIdx.x; row < SIZE; row += blockDim.x)
     {
-      // each thread picks a zero!
-      size_t z = gh.zeros[j];
-      int l = z % nrows; // row
-      int c = z / nrows; // column
-      int c1 = gh.column_of_star_at_row[l];
-      // printf("j %lu, z %lu, l %d, c %d, c1 %d\n", j, z, l, c, c1);
-      if (!v_cover_column[c] && !v_cover_row[l])
+      if (gh.cover_row[row])
+        continue;
+      int star_col = gh.column_of_star_at_row[row];
+      for (size_t z_col = 0; z_col < gh.zeros_sizes[row]; z_col++)
       {
-        s_found = true; // find uncovered zero
-        sh.repeat_kernel = true;
-        gh.column_of_prime_at_row[l] = c; // prime the uncovered zero
+        size_t col = gh.zeros[row * SIZE + z_col];
+        if (!v_cover_column[col])
+        {
+          uncovered_found = true;
+          gh.column_of_prime_at_row[row] = col;
 
-        if (c1 >= 0)
-        {
-          v_cover_row[l] = 1; // cover row
-          __threadfence();
-          v_cover_column[c1] = 0; // uncover column
-        }
-        else
-        {
-          sh.goto_5 = true;
+          if (star_col >= 0)
+          {
+            // there was a starred zero in this column → toggle covers & keep looping
+            gh.cover_row[row] = 1;
+            // atomicExch((int*)&v_cover_column[star_col], 0); // Atomic clear
+            v_cover_column[star_col] = 0;
+            // __threadfence_block();
+            break;
+          }
+          else
+          {
+            // no starred zero in this column → we're ready to augment
+            goto_5_flag = true;
+          }
         }
       }
-    } // for(int j
+    }
+    goto_5_flag = BlockReduce(temp_storage_goto).Reduce(goto_5_flag, cub::Max());
+    uncovered_found = BlockReduce(temp_storage_found).Reduce(uncovered_found, cub::Max());
+    if (threadIdx.x == 0) 
+    {
+      warp_uncovered_found = uncovered_found;
+      sh.goto_5 = goto_5_flag;
+    }
     __syncthreads();
-  } while (s_found && !sh.goto_5);
+  } while (warp_uncovered_found && !sh.goto_5);
 }
 
-template <typename data = int, uint blockSize = n_threads_reduction>
-__forceinline__ __device__ void min_reduce_kernel1(data *g_idata, data *g_odata,
-                                                   const size_t n, GLOBAL_HANDLE<data> &gh)
+fundef void min_reduce_kernel1(GLOBAL_HANDLE<data> &gh)
 {
-  data myval = MAX_DATA;
-  size_t i = threadIdx.x;
-  size_t gridSize = (size_t)blockSize * 2;
-  while (i < n)
-  {
-    size_t i1 = i;
-    size_t i2 = i + blockSize;
-    size_t l1 = i1 % nrows; // local index within the row
-    size_t c1 = i1 / nrows; // Row number
-    data g1 = MAX_DATA, g2 = MAX_DATA;
-    if (gh.cover_row[l1] == 1 || gh.cover_column[c1] == 1)
-      g1 = MAX_DATA;
-    else
-      g1 = g_idata[i1];
-    if (i2 < n)
-    {
-      size_t l2 = i2 % nrows;
-      size_t c2 = i2 / nrows;
-      if (gh.cover_row[l2] == 1 || gh.cover_column[c2] == 1)
-        g2 = MAX_DATA;
-      else
-        g2 = g_idata[i2];
-    }
-    myval = min(myval, min(g1, g2));
-    i += gridSize;
-  }
-  __syncthreads();
   typedef cub::BlockReduce<data, blockSize> BlockReduce;
   __shared__ typename BlockReduce::TempStorage temp_storage;
-  data minimum = BlockReduce(temp_storage).Reduce(myval, cub::Min());
-  if (threadIdx.x == 0)
-    *g_odata = minimum;
-}
-
-fundef void step_6_init(GLOBAL_HANDLE<data> &gh, SHARED_HANDLE &sh)
-{
-  // size_t id = (size_t)threadIdx.x + (size_t)blockIdx.x * (size_t)blockDim.x;
-  if (threadIdx.x == 0)
-    sh.zeros_size = 0;
-  for (uint i = threadIdx.x; i < SIZE; i += blockDim.x)
+  // strided reductions for each thread
+  data thread_min = (data)MAX_DATA;
+  // for (size_t row = 0; row < SIZE; row++)
+  // {
+  //   if (gh.cover_row[row])
+  //     continue;
+  //   for (size_t col = threadIdx.x; col < SIZE; col += blockDim.x)
+  //   {
+  //     data x = gh.slack[row * SIZE + col];
+  //     if (!gh.cover_column[col])
+  //       thread_min = min(thread_min, x);
+  //   }
+  // }
+  for (size_t i = threadIdx.x; i < SIZE * SIZE; i += blockDim.x)
   {
-    if (gh.cover_column[i] == 0)
-      gh.min_in_rows[i] += gh.d_min_in_mat[0] / 2;
-    else
-      gh.min_in_rows[i] -= gh.d_min_in_mat[0] / 2;
-    if (gh.cover_row[i] == 0)
-      gh.min_in_cols[i] += gh.d_min_in_mat[0] / 2;
-    else
-      gh.min_in_cols[i] -= gh.d_min_in_mat[0] / 2;
+    int row = i / SIZE;
+    int col = i % SIZE;
+    if (!gh.cover_row[row] && !gh.cover_column[col])
+      thread_min = min(thread_min, gh.slack[i]);
   }
-  __syncthreads();
+
+  thread_min = BlockReduce(temp_storage).Reduce(thread_min, cub::Min());
+  if (threadIdx.x == 0)
+    gh.d_min_in_mat[0] = thread_min;
 }
 
 /* STEP 5:
@@ -328,47 +224,38 @@ fundef void step_5a(GLOBAL_HANDLE<data> gh)
     int r_Z0, c_Z0;
 
     c_Z0 = gh.column_of_prime_at_row[i];
-    if (c_Z0 >= 0 && gh.column_of_star_at_row[i] < 0) // if primed and not covered
+    if (c_Z0 >= 0 && gh.column_of_star_at_row[i] < 0) // if primed zero does not share a row with a starred zero
     {
       gh.row_of_green_at_column[c_Z0] = i; // mark the column as green
 
-      while ((r_Z0 = gh.row_of_star_at_column[c_Z0]) >= 0)
+      while ((r_Z0 = gh.row_of_star_at_column[c_Z0]) >= 0) // get row of star in the same column
       {
-        c_Z0 = gh.column_of_prime_at_row[r_Z0];
-        gh.row_of_green_at_column[c_Z0] = r_Z0;
+        c_Z0 = gh.column_of_prime_at_row[r_Z0]; // get column of prime in the same column as current star (should always exist)
+        gh.row_of_green_at_column[c_Z0] = r_Z0; // mark the column as green
       }
     }
   }
 }
 
-// Applies the alternating paths
+// // Applies the alternating paths
 fundef void step_5b(GLOBAL_HANDLE<data> &gh)
 {
-  // size_t j = (size_t)blockDim.x * (size_t)blockIdx.x + (size_t)threadIdx.x;
-  for (size_t j = threadIdx.x; j < SIZE; j += blockDim.x)
+  for (size_t c = threadIdx.x; c < SIZE; c += blockDim.x)
   {
-    int r_Z0, c_Z0, c_Z2;
+    int row = gh.row_of_green_at_column[c];
+    int col = c;
 
-    r_Z0 = gh.row_of_green_at_column[j];
-
-    if (r_Z0 >= 0 && gh.row_of_star_at_column[j] < 0)
+    if (row >= 0 && gh.row_of_star_at_column[c] < 0)
     {
-
-      c_Z2 = gh.column_of_star_at_row[r_Z0];
-
-      gh.column_of_star_at_row[r_Z0] = j;
-      gh.row_of_star_at_column[j] = r_Z0;
-
-      while (c_Z2 >= 0)
-      {
-        r_Z0 = gh.row_of_green_at_column[c_Z2]; // row of Z2
-        c_Z0 = c_Z2;                            // col of Z2
-        c_Z2 = gh.column_of_star_at_row[r_Z0];  // col of Z4
-
-        // star Z2
-        gh.column_of_star_at_row[r_Z0] = c_Z0;
-        gh.row_of_star_at_column[c_Z0] = r_Z0;
-      }
+      int next_col = gh.column_of_star_at_row[row];
+      while (1) {
+        gh.column_of_star_at_row[row] = col;
+        gh.row_of_star_at_column[col] = row;
+        if (next_col < 0) break;
+        col = next_col;
+        row = gh.row_of_green_at_column[col];
+        next_col = gh.column_of_star_at_row[row];
+      };
     }
   }
 }
@@ -376,75 +263,43 @@ fundef void step_5b(GLOBAL_HANDLE<data> &gh)
 fundef void step_6_add_sub_fused_compress_matrix(GLOBAL_HANDLE<data> &gh, SHARED_HANDLE &sh) // For single block
 {
   // STEP 6:
-  /*STEP 6: Add the minimum uncovered value to every element of each covered
-  row, and subtract it from every element of each uncovered column.
+  /*STEP 6: Add the minimum uncovered value to every element covered by both a row and column, 
+  and subtract it from every uncovered element.
   Return to Step 4 without altering any stars, primes, or covered lines. */
   // const size_t i = (size_t)blockDim.x * (size_t)blockIdx.x + (size_t)threadIdx.x;
+
+  for (size_t i = threadIdx.x; i < SIZE; i += blockDim.x)
+    gh.zeros_sizes[i] = 0;
+  __syncthreads();
+
+  data offset = gh.d_min_in_mat[0];
+
+  // for (size_t row = 0; row < SIZE; row++) {
+  //   int cover_row = gh.cover_row[row];
+  //   for (size_t col = threadIdx.x; col < SIZE; col += blockDim.x)
+  //   {
+  //     size_t i = row * SIZE + col;
+  //     data x = gh.slack[i] + (cover_row + gh.cover_column[col] - 1) * offset;
+  //     gh.slack[i] = x;
+  //     if (x == 0)
+  //     {
+  //       int z_col = atomicAdd(&gh.zeros_sizes[row], 1);
+  //       gh.zeros[row * SIZE + z_col] = col;
+  //     }
+  //   }
+  // }
   for (size_t i = threadIdx.x; i < SIZE * SIZE; i += blockDim.x)
   {
-    const size_t l = i % nrows;
-    const size_t c = i / nrows;
-    auto reg = gh.slack[i];
-    switch (gh.cover_row[l] + gh.cover_column[c])
+    int row = i / SIZE;
+    int col = i % SIZE;
+    data x = gh.slack[i] + (gh.cover_row[row] + gh.cover_column[col] - 1) * offset;
+    gh.slack[i] = x;
+    if (x == 0)
     {
-    case 2:
-      reg += gh.d_min_in_mat[0];
-      gh.slack[i] = reg;
-      break;
-    case 0:
-      reg -= gh.d_min_in_mat[0];
-      gh.slack[i] = reg;
-      break;
-    default:
-      break;
-    }
-
-    // compress matrix
-    if (near_zero(reg))
-    {
-      int j = atomicAdd(&sh.zeros_size, 1);
-      gh.zeros[j] = i;
+      int z_col = atomicAdd(&gh.zeros_sizes[row], 1);
+      gh.zeros[row * SIZE + z_col] = col;
     }
   }
-}
-
-// template <typename data = int>
-fundef void printArray(data *idata, size_t len = SIZE, const char *message = NULL)
-{
-  __syncthreads();
-#ifdef __DEBUG__D
-  if (threadIdx.x == 0)
-  {
-    if (message != NULL)
-      printf("%s: ", message);
-    for (uint i = 0; i < len; i++)
-    {
-      printf("%d, ", idata[i]);
-    }
-    printf("\n");
-  }
-  __syncthreads();
-#endif
-}
-
-fundef void printMatrix(data *idata)
-{
-  __syncthreads();
-#ifdef __DEBUG__D
-  if (threadIdx.x == 0)
-  {
-    for (uint i = 0; i < SIZE; i++)
-    {
-      for (uint j = 0; j < SIZE; j++)
-      {
-        printf("%f, ", idata[SIZE * i + j]);
-      }
-      printf("\n");
-    }
-    printf("\n\n");
-  }
-  __syncthreads();
-#endif
 }
 
 fundef void set_handles(TILED_HANDLE<data> &th, GLOBAL_HANDLE<data> &gh, uint &problemID)
@@ -456,150 +311,82 @@ fundef void set_handles(TILED_HANDLE<data> &th, GLOBAL_HANDLE<data> &gh, uint &p
     // problemID = b;
     if (problemID < NPROB)
     {
+      // gh.SIZE = SIZE;
       // External memory
-      gh.cost = &th.cost[(size_t)problemID * SIZE * SIZE];
       gh.slack = &th.slack[(size_t)problemID * SIZE * SIZE];
-      gh.column_of_star_at_row = &th.column_of_star_at_row[problemID * nrows];
-      gh.objective = &th.objective[problemID * 1];
-      gh.objective[0] = 0;
+      gh.column_of_star_at_row = &th.column_of_star_at_row[(size_t)problemID * SIZE];
+      gh.row_of_star_at_column = &th.row_of_star_at_column[(size_t)problemID * SIZE];
 
-      if (th.memoryloc == INTERNAL)
-      {
-        gh.min_in_rows = &th.min_in_rows[b * nrows];
-        gh.min_in_cols = &th.min_in_cols[b * ncols];
-        gh.row_of_star_at_column = &th.row_of_star_at_column[b * ncols];
-      }
-      else if (th.memoryloc == EXTERNAL)
-      {
-        gh.min_in_rows = &th.min_in_rows[problemID * nrows];
-        gh.min_in_cols = &th.min_in_cols[problemID * ncols];
-        gh.row_of_star_at_column = &th.row_of_star_at_column[problemID * ncols];
-      }
       // Internal memory
-
-      gh.zeros = &th.zeros[b * nrows * ncols];
-      gh.cover_row = &th.cover_row[b * nrows];
-      gh.cover_column = &th.cover_column[b * ncols];
-      gh.column_of_prime_at_row = &th.column_of_prime_at_row[b * nrows];
-      gh.row_of_green_at_column = &th.row_of_green_at_column[b * ncols];
-      gh.max_in_mat_row = &th.max_in_mat_row[b * nrows];
-      gh.max_in_mat_col = &th.max_in_mat_col[b * ncols];
+      gh.zeros = &th.zeros[b * SIZE * SIZE];
+      gh.zeros_sizes = &th.zeros_sizes[b * SIZE];
+      gh.cover_row = &th.cover_row[b * SIZE];
+      gh.cover_column = &th.cover_column[b * SIZE];
+      gh.column_of_prime_at_row = &th.column_of_prime_at_row[b * SIZE];
+      gh.row_of_green_at_column = &th.row_of_green_at_column[b * SIZE];
       gh.d_min_in_mat = &th.d_min_in_mat[b * 1];
     }
   }
-  __syncthreads();
-}
-
-template <typename data = int, uint BLOCK_DIM_X>
-__launch_bounds__(BLOCK_DIM_X)
-    __global__ void BHA(GLOBAL_HANDLE<data> gh)
-{
-  __shared__ SHARED_HANDLE sh;
-  BHA(gh, sh);
 }
 
 fundef void BHA(GLOBAL_HANDLE<data> &gh, SHARED_HANDLE &sh, const uint problemID = 0)
 {
-
   init(gh);
-  calc_row_min(gh);
+  row_sub(gh);
   __syncthreads();
-  row_sub(gh, sh);
+  col_sub_and_compress_matrix(gh);
   __syncthreads();
-  calc_col_min(gh);
-  __syncthreads();
-  col_sub(gh);
-  __syncthreads();
-  compress_matrix(gh, sh);
-  __syncthreads();
+  step_2(gh, sh);
 
-  do
-  {
-    __syncthreads();
-    if (threadIdx.x == 0)
-      sh.repeat_kernel = false;
-    __syncthreads();
-    step_2(gh, sh);
-    __syncthreads();
-  } while (sh.repeat_kernel);
-  __syncthreads();
   while (1)
   {
-    __syncthreads();
-    step_3_init(gh, sh);
-    __syncthreads();
+    // if (threadIdx.x == 0) printf("Start step 3 ");
     step_3(gh, sh);
     __syncthreads();
+    // if (threadIdx.x == 0) printf("End step 3 ");
     if (sh.n_matches >= SIZE)
-      break;
-    step_4_init(gh);
-    __syncthreads();
+      return;
+    step_4_init(gh, sh);
 
     while (1)
     {
-      do
-      {
-        __syncthreads();
-        step_4(gh, sh);
-        __syncthreads();
-      } while (sh.repeat_kernel && !sh.goto_5);
+      __syncthreads();
+      // if (threadIdx.x == 0) printf("Start step 4 ");
+      step_4(gh, sh);
       __syncthreads();
       if (sh.goto_5)
         break;
 
-      __syncthreads();
-      min_reduce_kernel1<data, n_threads_reduction>(gh.slack, gh.d_min_in_mat, SIZE * SIZE, gh);
-      __syncthreads();
+      min_reduce_kernel1(gh);
+      // __syncthreads();
 
-      if (gh.d_min_in_mat[0] <= 0)
-      {
-        __syncthreads();
-        if (threadIdx.x == 0)
-        {
-          printf("minimum element in problemID %u is non positive: %f\n", problemID, (float)gh.d_min_in_mat[0]);
-        }
-        return;
-      }
-      __syncthreads();
+      // if (threadIdx.x == 0) printf("End step 4 ");
 
-      step_6_init(gh, sh); // Also does dual update
-      __syncthreads();
+      // if (gh.d_min_in_mat[0] <= 0)
+      // {
+      //   __syncthreads();
+      //   if (threadIdx.x == 0)
+      //   {
+      //     printf("minimum element in problemID %u is non positive: %f\n", problemID, (float)gh.d_min_in_mat[0]);
+      //   }
+      //   return;
+      // }
+
+      // if (threadIdx.x == 0) printf("Start step 6 ");
 
       step_6_add_sub_fused_compress_matrix(gh, sh);
-      __syncthreads();
+      // if (threadIdx.x == 0) printf("End step 6 ");
     }
-    __syncthreads();
-
+    // if (threadIdx.x == 0) printf("Start step 5a ");
     step_5a(gh);
+    // if (threadIdx.x == 0) printf("Start step 5b ");
     __syncthreads();
     step_5b(gh);
-    __syncthreads();
+    // if (threadIdx.x == 0) printf("End step 5 ");
   }
-  __syncthreads();
-  #ifdef __DEBUG__
-  get_objective(gh);
-  #endif
 }
 
-fundef void get_objective(GLOBAL_HANDLE<data> &gh)
-{
-  typedef cub::BlockReduce<data, n_threads_reduction> BR;
-  __shared__ typename BR::TempStorage temp_storage;
-  data obj = 0;
-  for (uint c = threadIdx.x; c < SIZE; c += blockDim.x)
-  {
-    obj += gh.cost[c * SIZE + gh.row_of_star_at_column[c]];
-    // printf("r: %u, c: %u, obj: %f, cost: %f\n", c, gh.row_of_star_at_column[c], obj, 
-    //        (float)gh.cost[c * SIZE + gh.row_of_star_at_column[c]]);
-  }
-  obj = BR(temp_storage).Reduce(obj, cub::Sum());
-  if (threadIdx.x == 0)
-    gh.objective[0] = obj;
-
-  __syncthreads();
-}
-
-template <typename data, uint BLOCK_DIM_X>
+template <typename data>
 __global__ void THA(TILED_HANDLE<data> th)
 {
   __shared__ GLOBAL_HANDLE<data> gh;
@@ -612,7 +399,6 @@ __global__ void THA(TILED_HANDLE<data> th)
     __syncthreads();
     if (problemID >= NPROB)
       return;
-    __syncthreads();
     BHA<data>(gh, sh, problemID);
   }
   return;

--- a/csrc/include/utils.cuh
+++ b/csrc/include/utils.cuh
@@ -23,13 +23,12 @@ inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort =
   }
 }
 
-#define execKernel(kernel, exec_gridSize, exec_blockSize, stream, verbose, ...)                          \
-  {                                                                                                      \
-    dim3 grid(exec_gridSize);                                                                            \
-    dim3 block(exec_blockSize);                                                                          \
-                                                                                                         \
-    if (verbose)                                                                                         \
-      Log(debug, "Launching %s with nblocks: %u, blockDim: %u", #kernel, exec_gridSize, exec_blockSize); \
-    kernel<<<grid, block, 0, stream>>>(__VA_ARGS__);                                                     \
-    CUDA_RUNTIME(cudaGetLastError());                                                                    \
+#define execKernel(kernel, exec_gridSize, exec_nwarps, stream, verbose, ...)                               \
+  {                                                                                                        \
+    dim3 grid(exec_gridSize);                                                                              \
+    dim3 block(32, exec_nwarps);                                                                           \
+    if (verbose)                                                                                           \
+      Log(debug, "Launching %s with nblocks: %u, blockDim: (%u, 32)", #kernel, exec_gridSize, exec_nwarps);\
+    kernel<<<grid, block, 0, stream>>>(__VA_ARGS__);                                                       \
+    CUDA_RUNTIME(cudaGetLastError());                                                                      \
   }

--- a/csrc/include/utils.cuh
+++ b/csrc/include/utils.cuh
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <stdio.h>
 #include <stdarg.h>
+#include <ATen/cuda/CUDAContext.h>
 
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 
@@ -22,40 +23,13 @@ inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort =
   }
 }
 
-#define execKernel(kernel, gridSize, blockSize, deviceId, verbose, ...)                       \
-  {                                                                                           \
-    dim3 grid(gridSize);                                                                      \
-    dim3 block(blockSize);                                                                    \
-                                                                                              \
-    CUDA_RUNTIME(cudaSetDevice(deviceId));                                                    \
-    if (verbose)                                                                              \
-      Log(debug, "Launching %s with nblocks: %u, blockDim: %u", #kernel, gridSize, blockSize); \
-    kernel<<<grid, block>>>(__VA_ARGS__);                                                     \
-    CUDA_RUNTIME(cudaGetLastError());                                                         \
-    CUDA_RUNTIME(cudaDeviceSynchronize());                                                    \
-  }
-
-#define execKernel2(kernel, gridSize, blockSize, deviceId, verbose, ...) \
-  {                                                                      \
-    float singleKernelTime;                                              \
-    cudaEvent_t start, end;                                              \
-    CUDA_RUNTIME(cudaEventCreate(&start));                               \
-    CUDA_RUNTIME(cudaEventCreate(&end));                                 \
-    dim3 grid(gridSize);                                                 \
-    dim3 block(blockSize);                                               \
-                                                                         \
-    CUDA_RUNTIME(cudaSetDevice(deviceId));                               \
-    CUDA_RUNTIME(cudaEventRecord(start));                                \
-    kernel<<<grid, block>>>(__VA_ARGS__);                                \
-    CHECK_KERNEL(#kernel)                                                \
-    CUDA_RUNTIME(cudaPeekAtLastError());                                 \
-    CUDA_RUNTIME(cudaEventRecord(end));                                  \
-                                                                         \
-    CUDA_RUNTIME(cudaEventSynchronize(start));                           \
-    CUDA_RUNTIME(cudaEventSynchronize(end));                             \
-    CUDA_RUNTIME(cudaDeviceSynchronize());                               \
-    CUDA_RUNTIME(cudaEventElapsedTime(&singleKernelTime, start, end));   \
-                                                                         \
-    {                                                                    \
-    }                                                                    \
+#define execKernel(kernel, exec_gridSize, exec_blockSize, stream, verbose, ...)                          \
+  {                                                                                                      \
+    dim3 grid(exec_gridSize);                                                                            \
+    dim3 block(exec_blockSize);                                                                          \
+                                                                                                         \
+    if (verbose)                                                                                         \
+      Log(debug, "Launching %s with nblocks: %u, blockDim: %u", #kernel, exec_gridSize, exec_blockSize); \
+    kernel<<<grid, block, 0, stream>>>(__VA_ARGS__);                                                     \
+    CUDA_RUNTIME(cudaGetLastError());                                                                    \
   }

--- a/csrc/lap_torch.cu
+++ b/csrc/lap_torch.cu
@@ -3,63 +3,66 @@
 #include <cuda.h>
 #include <torch/torch.h>
 #include <pybind11/pybind11.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/util/Exception.h>
 #include "LAP/Hung_lap.cuh"
 #include "include/defs.cuh"
 #include "include/Timer.h"
 
 template <typename scalar_t>
-torch::Tensor solve(scalar_t* cost_matrix_ptr, uint batch_size, uint dim, uint device_idx) {
+torch::Tensor solve(at::Tensor cost_matrix) {
   // Create LAP solver instance
   Timer t;
-  TLAP<scalar_t> *solver = new TLAP<scalar_t>(batch_size, cost_matrix_ptr, dim, device_idx);
+  TLAP<scalar_t> solver(cost_matrix);
   auto time = t.elapsed();
   Log(debug, "LAP creation time %f s", time);
 
   // Solve the assignment problem
   t.reset();
-  solver->solve();
+  torch::Tensor assignments_tensor = solver.solve();
   time = t.elapsed();
   Log(debug, "LAP solving time %f s", time);
 
-  // Get assignments from column_of_star_at_row
-  auto options =
-    torch::TensorOptions()
-      .dtype(torch::kInt32)
-      .device(torch::kCUDA, device_idx)
-      .requires_grad(false);
-  torch::Tensor assignments_tensor = torch::empty({batch_size, dim}, options);
-  int32_t *assignments_data = assignments_tensor.data_ptr<int32_t>();
-  // cudaMemcpy(assignments_data, solver->th.row_of_star_at_column,
-  //            batch_size * dim * sizeof(int32_t), cudaMemcpyDeviceToDevice);
-  cudaMemcpy(assignments_data, solver->th.column_of_star_at_row,
-             batch_size * dim * sizeof(int32_t), cudaMemcpyDeviceToDevice);
-  delete solver;
   return assignments_tensor;
 }
 
 // Convert PyTorch tensor to raw pointer and call LAP solver
-torch::Tensor solve_lap(torch::Tensor const& cost_matrix) {
-  // Ensure the input is on CUDA
-  TORCH_CHECK(cost_matrix.is_cuda(), "Input tensor must be on CUDA");
+torch::Tensor solve_lap(torch::Tensor const& cost_matrix, at::Device device) {
+  // Ensure the target LAP solver device is a CUDA device
+  TORCH_CHECK(device.is_cuda(), "Expected a CUDA device (use CPU-based LAP solvers instead)");
   // Ensure the input is a 3D tensor
   TORCH_CHECK(cost_matrix.dim() == 3, "Input must be a 3D tensor");
   // Ensure the input is a square matrix
   TORCH_CHECK(cost_matrix.size(1) == cost_matrix.size(2),
               "Input must be a batch of square matrices");
+  at::Tensor local_costs, assignments_tensor;
 
-  const auto batch_size = cost_matrix.size(0);
-  const auto dim = cost_matrix.size(1);
-  const auto device_idx = cost_matrix.device().index();
+  at::cuda::CUDAGuard guard(device);
+  if (cost_matrix.device() == device)
+    local_costs = cost_matrix.clone();
+  else
+    local_costs = cost_matrix.cpu().to(device);
+  
+  switch (cost_matrix.scalar_type())
+  {
+  case torch::kInt32:
+    assignments_tensor = solve<int>(local_costs);
+    break;
+  case torch::kFloat32:
+    assignments_tensor = solve<float>(local_costs);
+    break;
+  default:
+    AT_ERROR("dtype not supported: torch.float32 and torch.int32 only!");
+  };
 
-  void *cost_matrix_ptr = static_cast<void *>(cost_matrix.data_ptr());
-  // Get raw pointer to tensor data
-  return AT_DISPATCH_ALL_TYPES(cost_matrix.scalar_type(), "solve_lap", [&] {
-    return solve<scalar_t>(reinterpret_cast<scalar_t *>(cost_matrix_ptr), batch_size, dim, device_idx);
-  });
+  if (cost_matrix.device() == device)
+    assignments_tensor = assignments_tensor.clone();
+  else
+    assignments_tensor = assignments_tensor.cpu().to(cost_matrix.device());
+  return assignments_tensor;
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("solve_lap", &solve_lap,
-        "Solve Linear Assignment Problem using Hungarian algorithm on GPU",
-        py::arg("cost_matrix"));
+        "Solve Linear Assignment Problem using Hungarian algorithm on GPU");
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "torch_lap_cuda"
 dynamic = ["version", "dependencies"]
 authors = [
   { name="Dmitrii Kobylianskii", email="kobad2@gmail.com" },
+  { name="Clinton Ansun Mo", email="clinton.mo@weblab.t.u-tokyo.ac.jp"}
 ]
 description = "PyTorch wrapper for HyLAC CUDA library for solving linear assignment problems."
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -156,8 +156,8 @@ setup(
             "torch_lap_cuda.egg-info",
         )
     ),
-    author="Dmitrii Kobylianskii",
-    author_email="kobad2@gmail.com",
+    author="Dmitrii Kobylianskii, Clinton Ansun Mo",
+    author_email="kobad2@gmail.com, clinton.mo@weblab.t.u-tokyo.ac.jp",
     description="PyTorch wrapper for HyLAC CUDA library for solving linear assignment problems.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
I'd like to provide a major revision/cleanup for the HyLAC integration with PyTorch. Here's a list of changes:

- Adopted `CUDACachingAllocator` for CUDA memory allocation to align with PyTorch's allocator behavior, improving future out-of-memory (OOM) diagnostics and overall stability.
- Switched to row-major zero-based indexing to eliminate redundant loops in steps 2 and 4.
- Removed unnecessary `__syncthreads()` calls.
- Optimized shared memory access patterns in steps 4 and 6 by leveraging local variables and `BlockReduce` synchronizations.
- Joined row/column minimum detection and subtraction steps to avoid unnecessary shared memory writes. `min_in_rows` and `min_in_cols` are not used outside of these steps, and have been removed.
- Integrated GPU-A → host (CPU) → GPU-B transfer into the host process to ensure memory visibility when HyLAC runs on a separate GPU.
- Applied `CUDAGuard` to correctly set the active CUDA device/context in accordance to PyTorch.
- Bound kernel execution to the current PyTorch CUDA stream.
- Removed `near_zero`, as self-subtraction should result in exact 0s under IEEE754 iff the float is finite (NaNs and infinites are not expected in the kernel evaluation itself).

1024-thread execution with proper coalescing and minimal syncs provides a notable boost in performance:
(Benchmark results on A5000 GPU vs Ryzen Threadripper PRO 3975WX CPU (single-thread)):
```
Benchmark for uniform random distribution:
|------------------------------------------------------------------|
| Batch Size | Dimension  |    Scipy     |   LAP CUDA   | Speedup  |
|------------|------------|--------------|--------------|----------|
|     1      |     64     |   0.000124   |   0.001480   |  0.08  x |
|     1      |    256     |   0.001803   |   0.016088   |  0.11  x |
|     1      |    512     |   0.009899   |   0.119891   |  0.08  x |
|     64     |     64     |   0.007755   |   0.000899   |  8.63  x |
|     64     |    256     |   0.149330   |   0.030576   |  4.88  x |
|     64     |    512     |   0.691736   |   0.230714   |  3.00  x |
|    256     |     64     |   0.031951   |   0.002363   |  13.52 x |
|    256     |    256     |   0.604805   |   0.098345   |  6.15  x |
|    256     |    512     |   2.744047   |   0.805232   |  3.41  x |
|------------------------------------------------------------------|

Benchmark for normal random distribution:
|------------------------------------------------------------------|
| Batch Size | Dimension  |    Scipy     |   LAP CUDA   | Speedup  |
|------------|------------|--------------|--------------|----------|
|     1      |     64     |   0.000132   |   0.000819   |  0.16  x |
|     1      |    256     |   0.002049   |   0.017532   |  0.12  x |
|     1      |    512     |   0.007770   |   0.149853   |  0.05  x |
|     64     |     64     |   0.007439   |   0.001042   |  7.14  x |
|     64     |    256     |   0.130305   |   0.032099   |  4.06  x |
|     64     |    512     |   0.586193   |   0.256228   |  2.29  x |
|    256     |     64     |   0.029943   |   0.002617   |  11.44 x |
|    256     |    256     |   0.527141   |   0.110059   |  4.79  x |
|    256     |    512     |   2.317776   |   0.923647   |  2.51  x |
|------------------------------------------------------------------|

Benchmark for integer random distribution:
|------------------------------------------------------------------|
| Batch Size | Dimension  |    Scipy     |   LAP CUDA   | Speedup  |
|------------|------------|--------------|--------------|----------|
|     1      |     64     |   0.000132   |   0.000242   |  0.55  x |
|     1      |    256     |   0.001827   |   0.000696   |  2.62  x |
|     1      |    512     |   0.008852   |   0.000885   |  10.01 x |
|     64     |     64     |   0.007226   |   0.000329   |  21.95 x |
|     64     |    256     |   0.117021   |   0.000995   | 117.58 x |
|     64     |    512     |   0.519776   |   0.001768   | 293.94 x |
|    256     |     64     |   0.029074   |   0.000743   |  39.15 x |
|    256     |    256     |   0.479657   |   0.002933   | 163.55 x |
|    256     |    512     |   2.068405   |   0.004885   | 423.43 x |
|------------------------------------------------------------------|
```

I'd also like to include my name in the list of authors.